### PR TITLE
ci: simplify CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,6 @@ jobs:
     steps:
       - name: Checkout git repository
         uses: actions/checkout@v2
-      - name: Setup Node.js for use with Actions
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.16.3'
-      - name: Install Yarn
-        run: curl -o- -L https://yarnpkg.com/install.sh | bash
       - name: Get yarn cache
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -46,12 +40,6 @@ jobs:
     steps:
       - name: Checkout git repository
         uses: actions/checkout@v2
-      - name: Setup Node.js for use with Actions
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.16.3'
-      - name: Install Yarn
-        run: curl -o- -L https://yarnpkg.com/install.sh | bash
       - name: Get yarn cache
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -88,12 +76,6 @@ jobs:
     steps:
       - name: Checkout git repository
         uses: actions/checkout@v2
-      - name: Setup Node.js for use with Actions
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.16.3'
-      - name: Install Yarn
-        run: curl -o- -L https://yarnpkg.com/install.sh | bash
       - name: Get yarn cache
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -118,12 +100,6 @@ jobs:
     steps:
       - name: Checkout git repository
         uses: actions/checkout@v2
-      - name: Setup Node.js for use with Actions
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.16.3'
-      - name: Install Yarn
-        run: curl -o- -L https://yarnpkg.com/install.sh | bash
       - name: Get yarn cache
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -154,12 +130,6 @@ jobs:
     steps:
       - name: Checkout git repository
         uses: actions/checkout@v2
-      - name: Setup Node.js for use with Actions
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.16.3'
-      - name: Install Yarn
-        run: curl -o- -L https://yarnpkg.com/install.sh | bash
       - name: Get yarn cache
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -198,12 +168,6 @@ jobs:
     steps:
       - name: Checkout git repository
         uses: actions/checkout@v2
-      - name: Setup Node.js for use with Actions
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.16.3'
-      - name: Install Yarn
-        run: curl -o- -L https://yarnpkg.com/install.sh | bash
       - name: Get yarn cache
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"


### PR DESCRIPTION
## Summary

This removes all the manual Yarn and Node.js setup, since the Ubuntu image
already has them installed.

## Results

By using the pre-installed versions of tools we can increase build time by a considerable amount.
Only jobs that were updated are shown below.

| Job            | Original time | New time | Diff |
| -------------- | ------------- | -------- | ---- |
| `build`        | 53s           | 49s      | -4s  |
| `lint`         | 60s           | 43s      | -17s |
| `style`        | 45s           | 33s      | -12s |
| `style-prisma` | 42s           | 37s      | -5s  |
| `deploy`       | 255s          |          |      |
| `e2e-test`     | 45s           |          |      |
| Total          | 200s          | 162s     | -38s |
